### PR TITLE
Have default-accessor-name-transformer obey :accessor-name-package.

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -70,6 +70,8 @@ simply define a wrapping macro (without importing =nclasses:define-start=):
   - No longer try to export =NIL=.
   - Always return the class.
   - Avoid unneeded =progn=.
+  - Do not generate accessors in foreign packages when =:accessor-name-package=
+    is =:slot-name= and =:accessor= is not provided.
 
 ** Change Log
 

--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -206,21 +206,21 @@ If the slot is a boolean, it ensures the name is suffixed with \"?\"."
   (concatenate-symbol name #.(symbol-package :asdf)))
 
 (defun slot-type-maybe-inherited (initform slot-name definition superclasses)
-  (let ((all-parents-finalized-p
-          (and
-           (every (lambda (s) (find-class s nil)) superclasses)
-           (every #'closer-mop:class-finalized-p
-                  (mapcar (lambda (s) (find-class s nil)) superclasses)))))
-    (cond
-      ((and all-parents-finalized-p
-            (find slot-name (apply #'append (mapcar #'mopu:slot-names superclasses))))
-       (let ((parent (find (list slot-name) superclasses
-                           :key #'mopu:slot-names :test #'intersection)))
-         (when parent
-           (getf (mopu:slot-properties parent slot-name) :type))))
-      (all-parents-finalized-p
-       (funcall *type-inference* initform slot-name definition))
-      (t nil))))
+  (if (null superclasses)
+      (funcall *type-inference* initform slot-name definition)
+      (let ((superclasses (mapcar (lambda (s) (find-class s nil)) superclasses)))
+        (when superclasses
+          (let ((all-parents-finalized-p (every #'closer-mop:class-finalized-p superclasses)))
+            (cond
+              ((and all-parents-finalized-p
+                    (find slot-name (apply #'append (mapcar #'mopu:slot-names superclasses))))
+               (let ((parent (find (list slot-name) superclasses
+                                   :key #'mopu:slot-names :test #'intersection)))
+                 (when parent
+                   (getf (mopu:slot-properties parent slot-name) :type))))
+              (all-parents-finalized-p
+               (funcall *type-inference* initform slot-name definition))
+              (t nil)))))))
 
 (defun process-slot-definition (definition &key superclasses)
   (unless (consp definition)

--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -162,7 +162,7 @@ It takes 3 arguments:
 (defun default-accessor-name-transformer (name definition)
   "Return an accessor name following the slot name NAME."
   (declare (ignore definition))
-  name)
+  (intern (symbol-name name) (slot-name-package name)))
 
 (defun dwim-accessor-name-transformer (name definition)
   "Return an accessor name using the slot name NAME suffixed with \"-OF\".

--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -276,7 +276,9 @@ If the slot is a boolean, it ensures the name is suffixed with \"?\"."
                                (if (and (eq accessor 'missing)
                                         (eq reader 'missing)
                                         (eq writer 'missing))
-                                   (when *automatic-accessors-p*
+                                   (when (and *automatic-accessors-p*
+                                              (or (eq (symbol-package name) *package*)
+                                                  (not (eq *accessor-name-package* :slot-name))))
                                      (maybe-warn-for-slot-name)
                                      (setf accessor (transform-accessor))
                                      (list :accessor accessor))
@@ -460,6 +462,12 @@ New class options (defaults are NIL unless specified):
 
 - `:automatic-accessors-p': Whether to generate accessor names automatically for
   all slots.
+
+  As a special case, the accessor is not generated if all following conditions are met:
+  - `:accessor-name-package' is `:slot-name',
+  - slot name package is different from current package,
+  - if the `:accessor' slot option is not provided,
+
 
 - `:initarg-name-transformer' (default: `default-initarg-name-transformer'.)
 

--- a/test/test.lisp
+++ b/test/test.lisp
@@ -225,27 +225,27 @@
     (let ((*package* pkg1))
       (eval
        '(define-class nclasses/test.pkg1::foo ()
-         ((nclasses/test.pkg1::foo-name :accessor nil)))))
+         ((nclasses/test.pkg1::foo-desc :accessor nil)))))
     (let ((*package* pkg2))
       (eval
        '(define-class nclasses/test.pkg2::bar (nclasses/test.pkg1::foo)
          ;; override the slot in the superclass
-         ((nclasses/test.pkg1::foo-name :initform "")))))
-    (assert-false (fboundp 'nclasses/test.pkg1::foo-name))
+         ((nclasses/test.pkg1::foo-desc :initform "")))))
+    (assert-false (fboundp 'nclasses/test.pkg1::foo-desc))
     (let ((*package* pkg2))
       (eval '(define-class nclasses/test.pkg2::baz (nclasses/test.pkg1::foo)
               ;; override the slot in the superclass
-              ((nclasses/test.pkg1::foo-name :initform ""
+              ((nclasses/test.pkg1::foo-desc :initform ""
                                              :accessor t)))))
-    (assert-false (fboundp 'nclasses/test.pkg1::foo-name))
+    (assert-false (fboundp 'nclasses/test.pkg1::foo-desc))
     (let ((*package* pkg2))
       (eval '(define-class nclasses/test.pkg2::qux (nclasses/test.pkg1::foo)
               ;; override the slot in the superclass
-              ((nclasses/test.pkg1::foo-name :initform ""
+              ((nclasses/test.pkg1::foo-desc :initform ""
                                              :accessor t))
               (:accessor-name-package :slot-name))))
-    (assert-true (fboundp 'nclasses/test.pkg1::foo-name))
-    (fmakunbound 'nclasses/test.pkg1::foo-name)))
+    (assert-true (fboundp 'nclasses/test.pkg1::foo-desc))
+    (fmakunbound 'nclasses/test.pkg1::foo-desc)))
 
 (define-test accessor-generation-from-foreign-package-dwim (:contexts '(with-test-class-options))
   (let* ((pkg1 (find-package :nclasses/test.pkg1))
@@ -253,37 +253,38 @@
     (let ((*package* pkg1))
       (eval
        '(define-class nclasses/test.pkg1::foo ()
-         ((nclasses/test.pkg1::foo-name :accessor nil))
+         ((nclasses/test.pkg1::foo-bio :accessor nil))
          (:accessor-name-transformer 'dwim-accessor-name-transformer))))
     (let ((*package* pkg2))
       (eval
        '(define-class nclasses/test.pkg2::bar (nclasses/test.pkg1::foo)
          ;; override the slot in the superclass
-         ((nclasses/test.pkg1::foo-name :initform ""))
+         ((nclasses/test.pkg1::foo-bio :initform ""))
          (:accessor-name-transformer 'dwim-accessor-name-transformer))))
-    (assert-true (fboundp 'nclasses/test.pkg2::foo-name-of))
-    (assert-false (fboundp 'nclasses/test.pkg1::foo-name-of))
+
+    (assert-true (fboundp 'nclasses/test.pkg2::foo-bio-of))
+    (assert-false (fboundp 'nclasses/test.pkg1::foo-bio-of))
     (let ((*package* pkg2))
       (eval '(define-class nclasses/test.pkg2::baz (nclasses/test.pkg1::foo)
               ;; override the slot in the superclass
-              ((nclasses/test.pkg1::foo-name :initform ""
+              ((nclasses/test.pkg1::foo-bio :initform ""
                                              :accessor t)))))
-    (assert-false (fboundp 'nclasses/test.pkg1::foo-name-of))
+    (assert-false (fboundp 'nclasses/test.pkg1::foo-bio-of))
     (let ((*package* pkg2))
       (eval '(define-class nclasses/test.pkg2::qux (nclasses/test.pkg1::foo)
               ;; override the slot in the superclass
-              ((nclasses/test.pkg1::foo-name :initform ""))
+              ((nclasses/test.pkg1::foo-bio :initform ""))
               (:accessor-name-package :slot-name))))
-    (assert-false (fboundp 'nclasses/test.pkg1::foo-name-of))
+    (assert-false (fboundp 'nclasses/test.pkg1::foo-bio-of))
     (let ((*package* pkg2))
       (eval '(define-class nclasses/test.pkg2::qux (nclasses/test.pkg1::foo)
               ;; override the slot in the superclass
-              ((nclasses/test.pkg1::foo-name :initform ""
+              ((nclasses/test.pkg1::foo-bio :initform ""
                                              :accessor t))
               (:accessor-name-package :slot-name))))
-    (assert-true (fboundp 'nclasses/test.pkg1::foo-name-of))
-    (fmakunbound 'nclasses/test.pkg1::foo-name-of)
-    (fmakunbound 'nclasses/test.pkg2::foo-name-of)))
+    (assert-true (fboundp 'nclasses/test.pkg1::foo-bio-of))
+    (fmakunbound 'nclasses/test.pkg1::foo-bio-of)
+    (fmakunbound 'nclasses/test.pkg2::foo-bio-of)))
 
 (defvar street-name "bar")
 (define-test type-inference ()


### PR DESCRIPTION
In https://github.com/atlas-engineer/nyxt/pull/2784 we discovered an issue: accessors are generated in the slot package.

This fixes it by having accessors generated in the current package, just as with `dwim-accessor-name-transformer`.

But is it what we want?  In practice, it means that it we do not specify `:accessor nil`, a spurious accessor `active-attributes-keys` is generated.

An alternative would be to skip accessor generation if there is no `:accessor` slot option and if the parent slot has no accessor.