### PR TITLE
Add `define-generic` macro.

### DIFF
--- a/source/package.lisp
+++ b/source/package.lisp
@@ -7,6 +7,7 @@
   (:use :common-lisp)
   (:export #:define-class
            #:define-condition*
+           #:define-generic
            ;; transformers
            #:default-accessor-name-transformer
            #:dwim-accessor-name-transformer


### PR DESCRIPTION
Simplifies lots of `defgeneric` instances. 

Implemented without `alex:parse-body`, `serapeum:unparse-lambda-list` and other utilities, so may be slightly buggy. But, according to the spec, generic function arguments are processed properly and body is parsed in a more or less correct way.