### PR TITLE
Add alias macros.

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -152,8 +152,11 @@ See the =make-instance*= documentation for more examples and details.
 
 ** Changes from =defclass-star=
 
-- Renamed =defclass*= to =define-class=.
-- Renamed =defcondition*= to =define-condition*=.
+- Renamed =defclass*= to =define-class= (although =defclass*= is still available as alias, alongside =define-class*=).
+- Renamed =defcondition*= to =define-condition*= (=defcondition*= is still available as alias of =define-condition*=).
+- Added convenience macros beyond class definition:
+  - =define-generic= for concise generic function definition (with =defgeneric*= and =define-generic*= aliases).
+  - =make-instance*= (with =make*= alias) to abstract eponymous keywords and arguments and inline the =apply #'make-instance= idiom.
 - Default slot value when initform is omitted is =nil=.
   To leave slot unbound, specify =:unbound= as initform value.
 - Only the core system has been kept, the ContextL, hu.dwim.def and Swank

--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -513,6 +513,11 @@ New class options (defaults are NIL unless specified):
         ,processed-slots
         ,@clean-options))))
 
+(setf (macro-function 'defclass*) (macro-function 'define-class)
+      (documentation 'defclass* 'function) (documentation 'define-class 'function)
+      (macro-function 'define-class*) (macro-function 'define-class)
+      (documentation 'define-class* 'function) (documentation 'define-class 'function))
+
 (defmacro define-condition* (name supers slots &rest options)
   "To `define-condition' what `define-class' is to `defclass'.
 See `define-class' for more details."
@@ -522,6 +527,9 @@ See `define-class' for more details."
      `(define-condition ,name ,supers
         ,processed-slots
         ,@clean-options))))
+
+(setf (macro-function 'defcondition*) (macro-function 'define-condition*)
+      (documentation 'defcondition* 'function) (documentation 'define-condition* 'function))
 
 (defun generalize-arglist (arglist)
   "Generalizes ARGLIST to be accepted by `defgeneric' (3.4.2 of CLCS/CLHS).
@@ -607,6 +615,11 @@ Example:
        ,@options
        ,@(when documentation
            `((:documentation ,documentation))))))
+
+(setf (macro-function 'defgeneric*) (macro-function 'define-generic)
+      (documentation 'defgeneric* 'function) (documentation 'define-generic 'function)
+      (macro-function 'define-generic*) (macro-function 'define-generic)
+      (documentation 'define-generic* 'function) (documentation 'define-generic 'function))
 
 (defmacro make-instance* (class &rest arguments)
   "Convenience macro on top of `make-instance'.
@@ -695,3 +708,6 @@ the future." arguments))
       ,@arguments
       ,@(when last-appendable-form-p
           (list last-appendable-form)))))
+
+(setf (macro-function 'make*) (macro-function 'make-instance*)
+      (documentation 'make* 'function) (documentation 'make-instance* 'function))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -27,10 +27,10 @@
            #:make-name-transformer
            #:*allowed-slot-definition-properties*)
   (:documentation "This library offers four helper macros:
-- `nclasses:define-class'
-- `nclasses:define-condition*'.
-- `nclasses:define-generic'.
-- `nclasses:make-instance*'.
+- `nclasses:define-class' (aliases `nclasses:define-class*' and `nclasses:defclass*')
+- `nclasses:define-condition*' (alias `nclasses:defcondition*').
+- `nclasses:define-generic' (aliases `nclasses:define-generic*' and `nclasses:defgeneric*').
+- `nclasses:make-instance*' (alias `nclasses:make*').
 
 Compared to the standard macros, they accept extra options and slot definition
 is smarter.

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,9 +6,14 @@
 (defpackage :nclasses
   (:use :common-lisp)
   (:export #:define-class
+           #:defclass* ; alias
            #:define-condition*
+           #:defcondition* ; alias
            #:define-generic
+           #:define-generic* ; alias
+           #:defgeneric* ; alias
            #:make-instance*
+           #:make* ; alias
            ;; transformers
            #:default-accessor-name-transformer
            #:dwim-accessor-name-transformer


### PR DESCRIPTION
In #12 I mentioned that it'd be nice to have consistent aliases for our DWIM macros. Two reasons for that:
- Having star-suffixed names for all our macros (after all, the library distinguishing mark is a star after macro names :P).
- Having the standard+suffix names for our macros.

So, for `define-class`, aliases would be `define-class*` (consistency) and `defclass*` (standard+`*`). `defclass*`, in particular, would be useful for backwards-compatibility with `hu.dwim.defclass*` and drop-in use.

The implementation is based on setting `macro-function` of the alias to the macro function of the original macro. This is convenient, because SLIME/SLY goes to the original macro when cross-referencing the alias, and documentation is fetched properly for the alias macros (EDIT: only on some implementations, thus the explicit `(setf (documentation ...))` addition).

@Ambrevar, looks good? I think that after we merge (or reject) this, we can release 0.4.0—lots of new exciting stuff :D