### PR TITLE
Ensure docstrings and allow exporting generics

### DIFF
--- a/test/test.lisp
+++ b/test/test.lisp
@@ -534,7 +534,21 @@
      (:method ((a a) (b b) &key (c nil))
        (+ a b))
      (:method ((a x) (b z) &key c)
-       c))))
+       c)))
+  (assert-equal
+   `(prog1
+        (defgeneric generic
+            (a b &key c)
+          (:documentation "If :export-generic-name-p is true, export the name."))
+      (eval-when (:compile-toplevel :load-toplevel :execute)
+        (export 'generic ,(package-name *package*)))
+      (setf (documentation 'generic 'function)
+            "If :export-generic-name-p is true, export the name.")
+      (setf (documentation (fdefinition 'generic) 'function)
+            "If :export-generic-name-p is true, export the name."))
+   (macroexpand-1 '(define-generic generic (a b &key c)
+                    "If :export-generic-name-p is true, export the name."
+                    (:export-generic-name-p t)))))
 
 
 (define-test make-instance-star-backward-compatible ()


### PR DESCRIPTION
This adds two things:
- Documentation is set explicitly in `define-class`, `define-condition*`, and `define-generic`. Some implementation don't set `documentation`, thus hindering the interactive use. We're doing it for them.
- Allow exporting generics with `:export-generic-name-p` option for `define-generic` and `*export-generic-name-p*` global variable.

All covered with tests, obviously.