### PR TITLE
Add `make` as an alias for `make-instance*`.

### DIFF
--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -782,4 +782,6 @@ the future." arguments))
           (list last-appendable-form)))))
 
 (setf (macro-function 'make*) (macro-function 'make-instance*)
-      (documentation 'make* 'function) (documentation 'make-instance* 'function))
+      (documentation 'make* 'function) (documentation 'make-instance* 'function)
+      (macro-function 'make) (macro-function 'make-instance*)
+      (documentation 'make 'function) (documentation 'make-instance* 'function))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -14,6 +14,7 @@
            #:defgeneric* ; alias
            #:make-instance*
            #:make* ; alias
+           #:make ; alias
            ;; transformers
            #:default-accessor-name-transformer
            #:dwim-accessor-name-transformer
@@ -30,7 +31,7 @@
 - `nclasses:define-class' (aliases `nclasses:define-class*' and `nclasses:defclass*')
 - `nclasses:define-condition*' (alias `nclasses:defcondition*').
 - `nclasses:define-generic' (aliases `nclasses:define-generic*' and `nclasses:defgeneric*').
-- `nclasses:make-instance*' (alias `nclasses:make*').
+- `nclasses:make-instance*' (alias `nclasses:make*' and `nclasses:make').
 
 Compared to the standard macros, they accept extra options and slot definition
 is smarter.


### PR DESCRIPTION
This adds yet another alias for `make-instance*`: `make`. It's mainly here to make the exported API more consistent: there are both star-suffixed and star-less versions for most  constructs in Nclasses, but there's no star-less version of `make-instance`. So here it is: `make`.